### PR TITLE
Guard status sensor publish on error

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -59,7 +59,9 @@ bool Roode::handle_sensor_status() {
   }
   if (sensor_status < 28 && sensor_status != VL53L1_ERROR_NONE) {
     ESP_LOGE(TAG, "Ranging failed with an error. status: %d", sensor_status);
-    status_sensor->publish_state(sensor_status);
+    if (status_sensor != nullptr) {
+      status_sensor->publish_state(sensor_status);
+    }
     check_status = false;
   }
 


### PR DESCRIPTION
## Summary
- add a nullptr check around status_sensor publication in the error branch of handle_sensor_status
- ensure status_sensor usages are consistently guarded

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf8866b06c8322842c78692a52079e