### PR TITLE
Document VL53L1X calibration workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ People counter working with any smart home system which supports ESPHome/MQTT li
   - **Wemos D1 Mini ESP32** <-- Recommended
   - Wemos D1 mini (ESP8266)
   - NodeMCU V2
-- 1x VL53L1X
+- 1x VL53L1X driver that exposes calibration hooks and applies the range mode supplied by Roode
   - **Pololu** <-- Recommended
   - GY-53
   - Black PCB chinese sensor
@@ -84,6 +84,8 @@ roode:
 ```
 
 This uses the recommended default configuration.
+
+Under the hood, `Roode::calibrateDistance` evaluates recent idle distances to select the appropriate `Ranging::...` mode before commanding the driver.
 
 However, we offer a lot of flexibility. Here's the full configuration spelled out.
 


### PR DESCRIPTION
## Summary
- note that the VL53L1X driver now exposes calibration hooks and consumes the range mode provided by Roode
- explain that `Roode::calibrateDistance` picks the appropriate `Ranging::...` mode before sending commands to the driver

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf8fb815848322853954b04d941e62